### PR TITLE
Add CI for JSON schema validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,29 @@
+name: Validate HEF JSON
+
+on:
+  push:
+    paths:
+      - 'example.hef.json'
+      - 'schemas/**'
+      - 'validate.py'
+      - '.github/workflows/validate.yml'
+  pull_request:
+    paths:
+      - 'example.hef.json'
+      - 'schemas/**'
+      - 'validate.py'
+      - '.github/workflows/validate.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: python -m pip install jsonschema
+      - name: Run validation
+        run: python validate.py

--- a/validate.py
+++ b/validate.py
@@ -1,0 +1,24 @@
+import json
+import re
+from pathlib import Path
+import sys
+
+try:
+    import jsonschema
+except ImportError:
+    print('jsonschema package not installed', file=sys.stderr)
+    sys.exit(1)
+
+def load_jsonc(path: Path):
+    text = path.read_text()
+    # remove // comments
+    text = re.sub(r"//.*", "", text)
+    # remove /* */ comments
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return json.loads(text)
+
+schema = load_jsonc(Path('schemas/hef-schema.jsonc'))
+instance = load_jsonc(Path('example.hef.json'))
+
+jsonschema.validate(instance=instance, schema=schema)
+print('Validation succeeded')


### PR DESCRIPTION
## Summary
- add Python script for validating example HEF JSON file
- set up GitHub Actions workflow to run the validator on push and PR

## Testing
- `python validate.py` *(fails: jsonschema package not installed)*
- `pip install jsonschema` *(fails: could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_683e13cd68d48324bc03c263917cafc9